### PR TITLE
Fix sorting bug in mda.summary

### DIFF
--- a/R/mda.R
+++ b/R/mda.R
@@ -349,6 +349,6 @@ mda.summary <- function(res, id_cols="taxa", names_from="variable", method_from=
         pvalue =     pivot_wider(res, id_cols=id_cols, names_from=names_from, values_from=all_of(pvalue_from),     values_fn=list),
         qvalue =     pivot_wider(res, id_cols=id_cols, names_from=names_from, values_from=all_of(qvalue_from),     values_fn=list),
         effectsize = pivot_wider(res, id_cols=id_cols, names_from=names_from, values_from=all_of(effectsize_from), values_fn=list),
-        method_order = sort(as.data.frame(unique(res[,method_from]))[1,])
+        method_order = sort(as.data.frame(unique(res[,method_from]))[,1])
     )
 }

--- a/R/mda.R
+++ b/R/mda.R
@@ -349,6 +349,6 @@ mda.summary <- function(res, id_cols="taxa", names_from="variable", method_from=
         pvalue =     pivot_wider(res, id_cols=id_cols, names_from=names_from, values_from=all_of(pvalue_from),     values_fn=list),
         qvalue =     pivot_wider(res, id_cols=id_cols, names_from=names_from, values_from=all_of(qvalue_from),     values_fn=list),
         effectsize = pivot_wider(res, id_cols=id_cols, names_from=names_from, values_from=all_of(effectsize_from), values_fn=list),
-        method_order = sort(unique(res[,method_from]))
+        method_order = sort(as.data.frame(unique(res[,method_from]))[1,])
     )
 }


### PR DESCRIPTION
I couldn't execute the function, stemming from an error on this line (on R version 4.1.3 and having dplyr loaded) where it complains the following: 
```Warning message:
In xtfrm.data.frame(x) : cannot xtfrm data frames
```

I think this has to do with [this](https://win-vector.com/2021/02/07/it-has-always-been-wrong-to-call-order-on-a-data-frame/)
The following change seems to fix the issue at my end.
The as.data.frame was needed for my specific case (dplyr loaded).